### PR TITLE
fix: マージコミットでも Version Packages を検知できるよう修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
 
       # Version Packages PR がマージされた時のみタグとリリースを作成
       - name: Create tags and GitHub Releases
-        if: startsWith(github.event.head_commit.message, 'Version Packages')
+        if: contains(github.event.head_commit.message, 'Version Packages')
         run: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- `startsWith` から `contains` に変更
- マージコミットメッセージの本文に含まれる「Version Packages」も検知できるようにした

## 背景

GitHub のマージコミットは以下の形式:
```
Merge pull request #14 from Suntory-N-Water/changeset-release/main

Version Packages
```

`startsWith` では1行目しか見ないため、検知できなかった。

## Test plan

- [ ] Version Packages PR をマージ → タグとリリースが作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)